### PR TITLE
Fixed typo in Explore API OpenAPI spec: dataset results additional properties

### DIFF
--- a/generators/python-async/openapi/openapi.json
+++ b/generators/python-async/openapi/openapi.json
@@ -1428,9 +1428,9 @@
                 }
               }
             }
-          },
-          "additionalProperties": {}
-        }
+          }
+        },
+        "additionalProperties": {}
       },
       "results_dataset-v2.1": {
         "type": "object",

--- a/generators/python/openapi/openapi.json
+++ b/generators/python/openapi/openapi.json
@@ -1428,9 +1428,9 @@
                 }
               }
             }
-          },
-          "additionalProperties": {}
-        }
+          }
+        },
+        "additionalProperties": {}
       },
       "results_dataset-v2.1": {
         "type": "object",

--- a/python-async/docs/DatasetV21.md
+++ b/python-async/docs/DatasetV21.md
@@ -14,7 +14,6 @@ Name | Type | Description | Notes
 **features** | **List[str]** | A map of available features for a dataset, with the fields they apply to.  | [optional] 
 **metas** | **object** |  | [optional] 
 **fields** | [**List[DatasetV21FieldsInner]**](DatasetV21FieldsInner.md) |  | [optional] 
-**additional_properties** | **object** |  | [optional] 
 
 ## Example
 

--- a/python-async/opendatasoft_explore_async/models/dataset_v21.py
+++ b/python-async/opendatasoft_explore_async/models/dataset_v21.py
@@ -39,8 +39,8 @@ class DatasetV21(BaseModel):
     features: Optional[List[StrictStr]] = Field(default=None, description="A map of available features for a dataset, with the fields they apply to. ")
     metas: Optional[Dict[str, Any]] = None
     fields: Optional[List[DatasetV21FieldsInner]] = None
-    additional_properties: Optional[Any] = Field(default=None, alias="additionalProperties")
-    __properties: ClassVar[List[str]] = ["_links", "dataset_id", "dataset_uid", "attachments", "has_records", "data_visible", "features", "metas", "fields", "additionalProperties"]
+    additional_properties: Dict[str, Any] = {}
+    __properties: ClassVar[List[str]] = ["_links", "dataset_id", "dataset_uid", "attachments", "has_records", "data_visible", "features", "metas", "fields"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -73,9 +73,11 @@ class DatasetV21(BaseModel):
           were set at model initialization. Other fields with value `None`
           are ignored.
         * OpenAPI `readOnly` fields are excluded.
+        * Fields in `self.additional_properties` are added to the output dict.
         """
         excluded_fields: Set[str] = set([
             "dataset_uid",
+            "additional_properties",
         ])
 
         _dict = self.model_dump(
@@ -104,10 +106,10 @@ class DatasetV21(BaseModel):
                 if _item_fields:
                     _items.append(_item_fields.to_dict())
             _dict['fields'] = _items
-        # set to None if additional_properties (nullable) is None
-        # and model_fields_set contains the field
-        if self.additional_properties is None and "additional_properties" in self.model_fields_set:
-            _dict['additionalProperties'] = None
+        # puts key-value pairs in additional_properties in the top level
+        if self.additional_properties is not None:
+            for _key, _value in self.additional_properties.items():
+                _dict[_key] = _value
 
         return _dict
 
@@ -129,9 +131,13 @@ class DatasetV21(BaseModel):
             "data_visible": obj.get("data_visible"),
             "features": obj.get("features"),
             "metas": obj.get("metas"),
-            "fields": [DatasetV21FieldsInner.from_dict(_item) for _item in obj["fields"]] if obj.get("fields") is not None else None,
-            "additionalProperties": obj.get("additionalProperties")
+            "fields": [DatasetV21FieldsInner.from_dict(_item) for _item in obj["fields"]] if obj.get("fields") is not None else None
         })
+        # store additional fields in additional_properties
+        for _key in obj.keys():
+            if _key not in cls.__properties:
+                _obj.additional_properties[_key] = obj.get(_key)
+
         return _obj
 
 

--- a/python/docs/DatasetV21.md
+++ b/python/docs/DatasetV21.md
@@ -14,7 +14,6 @@ Name | Type | Description | Notes
 **features** | **List[str]** | A map of available features for a dataset, with the fields they apply to.  | [optional] 
 **metas** | **object** |  | [optional] 
 **fields** | [**List[DatasetV21FieldsInner]**](DatasetV21FieldsInner.md) |  | [optional] 
-**additional_properties** | **object** |  | [optional] 
 
 ## Example
 

--- a/python/opendatasoft_explore/models/dataset_v21.py
+++ b/python/opendatasoft_explore/models/dataset_v21.py
@@ -39,8 +39,8 @@ class DatasetV21(BaseModel):
     features: Optional[List[StrictStr]] = Field(default=None, description="A map of available features for a dataset, with the fields they apply to. ")
     metas: Optional[Dict[str, Any]] = None
     fields: Optional[List[DatasetV21FieldsInner]] = None
-    additional_properties: Optional[Any] = Field(default=None, alias="additionalProperties")
-    __properties: ClassVar[List[str]] = ["_links", "dataset_id", "dataset_uid", "attachments", "has_records", "data_visible", "features", "metas", "fields", "additionalProperties"]
+    additional_properties: Dict[str, Any] = {}
+    __properties: ClassVar[List[str]] = ["_links", "dataset_id", "dataset_uid", "attachments", "has_records", "data_visible", "features", "metas", "fields"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -73,9 +73,11 @@ class DatasetV21(BaseModel):
           were set at model initialization. Other fields with value `None`
           are ignored.
         * OpenAPI `readOnly` fields are excluded.
+        * Fields in `self.additional_properties` are added to the output dict.
         """
         excluded_fields: Set[str] = set([
             "dataset_uid",
+            "additional_properties",
         ])
 
         _dict = self.model_dump(
@@ -104,10 +106,10 @@ class DatasetV21(BaseModel):
                 if _item_fields:
                     _items.append(_item_fields.to_dict())
             _dict['fields'] = _items
-        # set to None if additional_properties (nullable) is None
-        # and model_fields_set contains the field
-        if self.additional_properties is None and "additional_properties" in self.model_fields_set:
-            _dict['additionalProperties'] = None
+        # puts key-value pairs in additional_properties in the top level
+        if self.additional_properties is not None:
+            for _key, _value in self.additional_properties.items():
+                _dict[_key] = _value
 
         return _dict
 
@@ -129,9 +131,13 @@ class DatasetV21(BaseModel):
             "data_visible": obj.get("data_visible"),
             "features": obj.get("features"),
             "metas": obj.get("metas"),
-            "fields": [DatasetV21FieldsInner.from_dict(_item) for _item in obj["fields"]] if obj.get("fields") is not None else None,
-            "additionalProperties": obj.get("additionalProperties")
+            "fields": [DatasetV21FieldsInner.from_dict(_item) for _item in obj["fields"]] if obj.get("fields") is not None else None
         })
+        # store additional fields in additional_properties
+        for _key in obj.keys():
+            if _key not in cls.__properties:
+                _obj.additional_properties[_key] = obj.get(_key)
+
         return _obj
 
 


### PR DESCRIPTION
Datast results additional properties were defined at the wrong level. As a consequence, the API client was not able to parse the result of select=title queries where title is serialized at the root of the dataset object and not anymore inside the default metadata template.